### PR TITLE
As discussed in issue #8, an approach to icon styling using colourabbrev.

### DIFF
--- a/nautical_active.json
+++ b/nautical_active.json
@@ -4794,6 +4794,20 @@
       ],
       "layout": {
         "icon-image": "P/P1.minor",
+        "icon-color": [
+          "match",
+          ["get", "colourabbrev"],
+          "", "yellow",
+          "Am", "orange",
+          "Bu", "blue",
+          "G", "lime",
+          "Or", "orange",
+          "R", "red",
+          "Vi", "violet",
+          "W", "yellow",
+          "Y", "yellow",
+          "magenta"
+        ],
         "icon-size": {
           "stops": [
             [
@@ -4835,6 +4849,20 @@
       ],
       "layout": {
         "icon-image": "P/P1.major",
+        "icon-color": [
+          "match",
+          ["get", "colourabbrev"],
+          "", "yellow",
+          "Am", "orange",
+          "Bu", "blue",
+          "G", "lime",
+          "Or", "orange",
+          "R", "red",
+          "Vi", "violet",
+          "W", "yellow",
+          "Y", "yellow",
+          "magenta"
+        ],
         "icon-size": {
           "stops": [
             [


### PR DESCRIPTION
@PetersonGIS, seems an approach like this should sync the calculated `colourabbrev` values coming from the provider layer with the colours. Merge/modify/ignore as you see fit.